### PR TITLE
fix: apply the q/a swap when the search value changes

### DIFF
--- a/components/QuestionsListLayout.tsx
+++ b/components/QuestionsListLayout.tsx
@@ -126,7 +126,7 @@ const QuestionsListLayout: FunctionComponent<IQuestionsListLayoutProps> = ({
   useEffect(() => {
     const updatedQnAs = swapFlowOfData(questionsToDisplay, flow);
     setQuestionsToDisplay(updatedQnAs);
-  }, [flow]);
+  }, [flow, searchValue]);
 
   const toggleFlow = () => {
     if (flow === Flow.A_TO_B) {


### PR DESCRIPTION
Previously, when the flow was "answer->question" and the user edited
the search field, the list was re-filtered correctly but was also
reverted to "question->answer" flow.

This was because the logic for swapping the question and answer only
ran when the flow was toggled. When the user edited the search value,
the list of questions to display was recomputed from scratch and the
swap was lost.

Fix this by also running the swap logic when the search value changes.

---

**DISCLAIMER:** Completely untested. Not sure if this is the best approach.