### PR TITLE
fix: enable search filtering on favorites list

### DIFF
--- a/components/QuestionsListLayout.tsx
+++ b/components/QuestionsListLayout.tsx
@@ -9,6 +9,7 @@ import FlowOfData from './FlowOfData';
 import PrintPageButton from './PrintPageButton';
 import FilterVisibilityModeButton from './FilterVisibilityModeButton';
 import CatchIntentCard from './CatchIntentCard';
+import { matchSorter } from 'match-sorter';
 
 const QuestionsListLayout: FunctionComponent = (): JSX.Element => {
   const {
@@ -18,6 +19,7 @@ const QuestionsListLayout: FunctionComponent = (): JSX.Element => {
     filterOptions,
     setFilterOption,
     setFlow,
+    searchValue,
   } = useStore();
 
   useEffect(() => {
@@ -44,6 +46,10 @@ const QuestionsListLayout: FunctionComponent = (): JSX.Element => {
 
   const questionsToRenderBasedOnFilterOptions = filterOptions.all
     ? questionsToDisplay
+    : searchValue
+    ? matchSorter(favoriteQuestions, searchValue, {
+        keys: ['question', 'answer', 'alternativeAnswers'],
+      })
     : favoriteQuestions;
 
   return (


### PR DESCRIPTION
This PR fixes a bug where the search bar was non-functional when viewing the "Favorites" tab. Previously, typing in the search bar would update the state but fail to filter the list of favorite questions.

**Changes:**

* Modified `components/QuestionsListLayout.tsx` to subscribe to the global `searchValue` from the store.
* Implemented conditional filtering on `favoriteQuestions` using `matchSorter`, mirroring the logic used for the main question list.

**Type of Change:**

* [x] Bug fix (non-breaking change which fixes an issue)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Search now returns more relevant results by intelligently matching and ranking questions, answers, and related content for better discoverability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->